### PR TITLE
Implement CRUD for Casos module with Zustand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,71 @@ Todas as mudanças notáveis deste projeto serão documentadas neste arquivo.
 
 ## [Não Lançado]
 
+### ETAPA 8 ✅ - CRUD de Casos + Feature Flags para Submódulos
+**Data**: 2026-01-08
+
+#### Adicionado
+- **Store de Casos para CRUD** (`src/state/casesStore.ts`):
+  - Zustand store com persistência em localStorage
+  - Complementa caseStore.ts (que gerencia caso aberto)
+  - Actions: fetchCases, createCase, updateCase, deleteCase
+  - Seletores: selectedCase(), getCaseById()
+  - Estado: cases[], selectedCaseId, loading
+  - Integração automática com casesService (mock ou API real)
+  - Exportado em state/index.ts
+
+- **Feature Flags para Submódulos de Casos** (`src/config/features.ts`):
+  - `captureModule`: Ativa/desativa Captura & IA
+  - `recognitionModule`: Ativa/desativa Reconhecimento Visuográfico
+  - `photoReportModule`: Ativa/desativa Relatório Fotográfico
+  - `investigationModule`: Ativa/desativa Relatório de Investigação
+  - `exportModule`: Ativa/desativa Exportação/PDF
+  - Todos defaultam para `true` (ativados)
+  - Override via .env: `VITE_FEATURE_CAPTUREMODULE=false`
+  - Metadados em ALL_FEATURES para documentação
+
+- **Rotas Condicionadas por Feature Flags** (`src/routes/AppRouter.tsx`):
+  - `/cases/:caseId/capture` → condicionado a captureModule
+  - `/cases/:caseId/recognition` → condicionado a recognitionModule
+  - `/cases/:caseId/photo-report` → condicionado a photoReportModule
+  - `/cases/:caseId/investigation` → condicionado a investigationModule
+  - `/cases/:caseId/export` → condicionado a exportModule
+  - Desativar flag remove rota e impede navegação
+
+- **Menu Lateral com Feature Flags** (`src/components/layout/Sidebar.tsx`):
+  - Cada submódulo do Sidebar agora usa sua flag específica
+  - "Captura & IA" usa `captureModule`
+  - "Reconhecimento" usa `recognitionModule`
+  - "Relatório Fotográfico" usa `photoReportModule`
+  - "Relatório de Investigação" usa `investigationModule`
+  - "Exportar Pacote" usa `exportModule`
+  - Menu items desaparecem se flag desativada
+
+#### Status
+- ✅ Build production: `npm run build` - SUCCESS
+- ✅ Dev server: `npm run dev` - SUCCESS
+- ✅ Store de Casos funcionando com persist
+- ✅ Feature flags para submódulos implementadas
+- ✅ Rotas condicionadas corretamente
+- ✅ Sidebar dinâmico baseado em flags
+- ✅ Padrão replicado de clientsStore
+- ✅ Estrutura preparada para ativação granular
+
+#### Padrão ETAPA 8
+Implementação seguindo padrão de Clientes (ETAPA 7):
+- **casesStore.ts** similar a **clientsStore.ts**
+- Serviço **casesService** já existente e integrado
+- Feature flags centralizadas em **features.ts**
+- Submódulos controláveis independentemente
+- localStorage persistence via Zustand
+- Mock data alternável via VITE_USE_MOCK_API
+
+#### Próximo
+- Implementar páginas CRUD adicionais (Create, Edit) se necessário
+- Integrar com API real (trocar VITE_USE_MOCK_API)
+
+---
+
 ### ETAPA 7 ✅ - Primeiro Vertical Slice (CRUD Clientes)
 **Data**: 2026-01-08
 

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -39,40 +39,41 @@ export function Sidebar() {
       path: '/cases',
       featureFlag: 'casesModule' as const,
     },
+    // Submódulos de Casos com feature flags individuais (ETAPA 8)
     {
       id: 'capture',
       label: 'Captura & IA',
       icon: Camera,
       path: caseId ? `/cases/${caseId}/capture` : null,
-      featureFlag: 'casesModule' as const,
+      featureFlag: 'captureModule' as const,
     },
     {
       id: 'recognition',
       label: 'Reconhecimento',
       icon: FileText,
       path: caseId ? `/cases/${caseId}/recognition` : null,
-      featureFlag: 'casesModule' as const,
+      featureFlag: 'recognitionModule' as const,
     },
     {
       id: 'photo-report',
       label: 'Relatório Fotográfico',
       icon: Image,
       path: caseId ? `/cases/${caseId}/photo-report` : null,
-      featureFlag: 'casesModule' as const,
+      featureFlag: 'photoReportModule' as const,
     },
     {
       id: 'investigation-report',
       label: 'Relatório de Investigação',
       icon: FileSearch,
       path: caseId ? `/cases/${caseId}/investigation` : null,
-      featureFlag: 'casesModule' as const,
+      featureFlag: 'investigationModule' as const,
     },
     {
       id: 'export',
       label: 'Exportar Pacote',
       icon: Package,
       path: caseId ? `/cases/${caseId}/export` : null,
-      featureFlag: 'casesModule' as const,
+      featureFlag: 'exportModule' as const,
     },
     // Clientes (condicionado por FEATURE_FLAGS.clientsModule - ETAPA 7)
     {

--- a/src/config/features.ts
+++ b/src/config/features.ts
@@ -14,6 +14,11 @@ export type FeatureFlagKey =
   | 'auth'
   | 'dashboard'
   | 'casesModule'
+  | 'captureModule'
+  | 'recognitionModule'
+  | 'photoReportModule'
+  | 'investigationModule'
+  | 'exportModule'
   | 'clientsModule'
   | 'reportsModule'
   | 'settingsModule'
@@ -40,6 +45,13 @@ const DEFAULT_FEATURES: Record<FeatureFlagKey, boolean> = {
   // Módulos principais
   dashboard: true,
   casesModule: true,
+
+  // Submódulos de Casos (ETAPA 8 - Feature Flags)
+  captureModule: true,
+  recognitionModule: true,
+  photoReportModule: true,
+  investigationModule: true,
+  exportModule: true,
 
   // Módulos opcionais
   clientsModule: true, // Ativado em ETAPA 7
@@ -73,6 +85,11 @@ export const FEATURE_FLAGS: Record<FeatureFlagKey, boolean> = {
   auth: getFeatureValue('auth'),
   dashboard: getFeatureValue('dashboard'),
   casesModule: getFeatureValue('casesModule'),
+  captureModule: getFeatureValue('captureModule'),
+  recognitionModule: getFeatureValue('recognitionModule'),
+  photoReportModule: getFeatureValue('photoReportModule'),
+  investigationModule: getFeatureValue('investigationModule'),
+  exportModule: getFeatureValue('exportModule'),
   clientsModule: getFeatureValue('clientsModule'),
   reportsModule: getFeatureValue('reportsModule'),
   settingsModule: getFeatureValue('settingsModule'),
@@ -101,6 +118,36 @@ export const ALL_FEATURES: FeatureFlag[] = [
     name: 'Módulo de Casos',
     description: 'Gerenciamento de casos de investigação',
     enabled: FEATURE_FLAGS.casesModule,
+  },
+  {
+    key: 'captureModule',
+    name: 'Captura & IA',
+    description: 'Submódulo de captura de fotos e classificação por IA',
+    enabled: FEATURE_FLAGS.captureModule,
+  },
+  {
+    key: 'recognitionModule',
+    name: 'Reconhecimento',
+    description: 'Submódulo de reconhecimento visuográfico',
+    enabled: FEATURE_FLAGS.recognitionModule,
+  },
+  {
+    key: 'photoReportModule',
+    name: 'Relatório Fotográfico',
+    description: 'Submódulo de geração de relatório fotográfico',
+    enabled: FEATURE_FLAGS.photoReportModule,
+  },
+  {
+    key: 'investigationModule',
+    name: 'Investigação',
+    description: 'Submódulo de relatório de investigação',
+    enabled: FEATURE_FLAGS.investigationModule,
+  },
+  {
+    key: 'exportModule',
+    name: 'Exportar Pacote',
+    description: 'Submódulo de exportação e geração de PDFs',
+    enabled: FEATURE_FLAGS.exportModule,
   },
   {
     key: 'clientsModule',

--- a/src/routes/AppRouter.tsx
+++ b/src/routes/AppRouter.tsx
@@ -59,11 +59,23 @@ export function AppRouter() {
             <>
               <Route path="/cases" element={<CasesListScreen />} />
               <Route path="/cases/:caseId" element={<CaseWorkspaceScreen />} />
-              <Route path="/cases/:caseId/capture" element={<CaptureAIScreen />} />
-              <Route path="/cases/:caseId/recognition" element={<RecognitionScreen />} />
-              <Route path="/cases/:caseId/photo-report" element={<PhotoReportScreen />} />
-              <Route path="/cases/:caseId/investigation" element={<InvestigationReportScreen />} />
-              <Route path="/cases/:caseId/export" element={<ExportScreen />} />
+
+              {/* Submódulos de Casos com feature flags individuais (ETAPA 8) */}
+              {FEATURE_FLAGS.captureModule && (
+                <Route path="/cases/:caseId/capture" element={<CaptureAIScreen />} />
+              )}
+              {FEATURE_FLAGS.recognitionModule && (
+                <Route path="/cases/:caseId/recognition" element={<RecognitionScreen />} />
+              )}
+              {FEATURE_FLAGS.photoReportModule && (
+                <Route path="/cases/:caseId/photo-report" element={<PhotoReportScreen />} />
+              )}
+              {FEATURE_FLAGS.investigationModule && (
+                <Route path="/cases/:caseId/investigation" element={<InvestigationReportScreen />} />
+              )}
+              {FEATURE_FLAGS.exportModule && (
+                <Route path="/cases/:caseId/export" element={<ExportScreen />} />
+              )}
             </>
           )}
 

--- a/src/state/casesStore.ts
+++ b/src/state/casesStore.ts
@@ -1,0 +1,171 @@
+/**
+ * Store de Casos - Zustand
+ * Gerencia estado global de casos para CRUD
+ * Complementa caseStore.ts (que gerencia um caso aberto)
+ */
+
+import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
+import { Case, createEmptyCase } from '@/types/case';
+import { casesService } from '@/services/casesService';
+import { v4 as uuidv4 } from 'uuid';
+
+interface CasesStore {
+  // Estado
+  cases: Case[];
+  selectedCaseId: string | null;
+  loading: boolean;
+
+  // Seletores
+  selectedCase: () => Case | null;
+  getCaseById: (id: string) => Case | undefined;
+
+  // Actions - Listar
+  fetchCases: () => Promise<void>;
+
+  // Actions - CRUD
+  createCase: (
+    bo: string,
+    natureza?: string,
+    endereco?: string,
+    dataHoraFato?: string
+  ) => Promise<Case>;
+  selectCase: (caseId: string | null) => void;
+  updateCase: (caseId: string, updates: Partial<Case>) => Promise<Case>;
+  deleteCase: (caseId: string) => Promise<void>;
+
+  // Actions - Utilitários
+  setLoading: (loading: boolean) => void;
+  clearCases: () => void;
+}
+
+/**
+ * Store Zustand com persistência em localStorage
+ * Foca em CRUD básico de casos
+ */
+export const useCasesStore = create<CasesStore>()(
+  persist(
+    (set, get) => ({
+      // Estado inicial
+      cases: [],
+      selectedCaseId: null,
+      loading: false,
+
+      // Seletor: caso selecionado
+      selectedCase: () => {
+        const { cases, selectedCaseId } = get();
+        if (!selectedCaseId) return null;
+        return cases.find((c) => c.id === selectedCaseId) || null;
+      },
+
+      // Seletor: caso por ID
+      getCaseById: (id: string) => {
+        return get().cases.find((c) => c.id === id);
+      },
+
+      // Action: buscar todos os casos
+      fetchCases: async () => {
+        set({ loading: true });
+        try {
+          const cases = await casesService.getCases();
+          set({ cases });
+        } catch (error) {
+          console.error('Erro ao buscar casos:', error);
+        } finally {
+          set({ loading: false });
+        }
+      },
+
+      // Action: criar novo caso
+      createCase: async (bo, natureza, endereco, dataHoraFato) => {
+        set({ loading: true });
+        try {
+          // Cria localmente primeiro
+          const id = uuidv4();
+          const newCase = createEmptyCase(id, bo);
+          if (natureza) newCase.natureza = natureza;
+          if (endereco) newCase.endereco = endereco;
+          if (dataHoraFato) newCase.dataHoraFato = dataHoraFato;
+
+          // Tenta persistir via serviço
+          let persistedCase = newCase;
+          try {
+            persistedCase = await casesService.createCase(bo);
+            // Copia dados adicionais para caso persistido
+            if (natureza) persistedCase.natureza = natureza;
+            if (endereco) persistedCase.endereco = endereco;
+            if (dataHoraFato) persistedCase.dataHoraFato = dataHoraFato;
+          } catch (error) {
+            console.warn('Erro ao persistir caso no serviço, usando local:', error);
+          }
+
+          set((state) => ({
+            cases: [...state.cases, persistedCase],
+          }));
+          return persistedCase;
+        } catch (error) {
+          console.error('Erro ao criar caso:', error);
+          throw error;
+        } finally {
+          set({ loading: false });
+        }
+      },
+
+      // Action: selecionar caso
+      selectCase: (caseId) => {
+        set({ selectedCaseId: caseId });
+      },
+
+      // Action: atualizar caso
+      updateCase: async (caseId, updates) => {
+        set({ loading: true });
+        try {
+          const updatedCase = await casesService.updateCase(caseId, updates);
+          set((state) => ({
+            cases: state.cases.map((c) => (c.id === caseId ? updatedCase : c)),
+          }));
+          return updatedCase;
+        } catch (error) {
+          console.error('Erro ao atualizar caso:', error);
+          throw error;
+        } finally {
+          set({ loading: false });
+        }
+      },
+
+      // Action: deletar caso
+      deleteCase: async (caseId) => {
+        set({ loading: true });
+        try {
+          await casesService.deleteCase(caseId);
+          set((state) => ({
+            cases: state.cases.filter((c) => c.id !== caseId),
+            selectedCaseId:
+              state.selectedCaseId === caseId ? null : state.selectedCaseId,
+          }));
+        } catch (error) {
+          console.error('Erro ao deletar caso:', error);
+          throw error;
+        } finally {
+          set({ loading: false });
+        }
+      },
+
+      // Action: definir loading
+      setLoading: (loading) => {
+        set({ loading });
+      },
+
+      // Action: limpar casos
+      clearCases: () => {
+        set({ cases: [], selectedCaseId: null });
+      },
+    }),
+    {
+      name: 'cases-store',
+      storage: createJSONStorage(() => localStorage),
+      // Persistir apenas casos (não carregamos dados do localStorage inicialmente)
+      partialize: (state) => ({ cases: state.cases }),
+    }
+  )
+);

--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -1,1 +1,3 @@
 export * from './caseStore';
+export * from './casesStore';
+export * from './clientsStore';


### PR DESCRIPTION
Implementação completa do CRUD de Casos com Zustand store e feature flags granulares para controlar submódulos internos.

Adicionado:
- casesStore.ts: Store Zustand com persistência em localStorage
  - Complementa caseStore.ts para gerenciamento de listagem
  - Actions: fetchCases, createCase, updateCase, deleteCase
  - Seletores: selectedCase(), getCaseById()
  - Integração automática com casesService

- Feature flags para submódulos em features.ts:
  - captureModule, recognitionModule, photoReportModule
  - investigationModule, exportModule
  - Todos defaultam para true (ativados)
  - Override via .env: VITE_FEATURE_<MODULE>=false

- Rotas condicionadas em AppRouter.tsx:
  - Cada submódulo verifica sua flag antes de renderizar
  - Desativar flag remove rota e impede navegação

- Menu lateral dinâmico em Sidebar.tsx:
  - Cada submódulo usa sua flag específica
  - Menu items desaparecem se flag desativada

- Documentação em CHANGELOG.md:
  - ETAPA 8 completa com status e estrutura

Status:
✅ Build: SUCCESS
✅ Dev server: SUCCESS
✅ Feature flags funcionando
✅ Estrutura preparada para ativação granular