### PR TITLE
Fix React JSX runtime module resolution error

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "dev": "vite"
   },
   "dependencies": {
+    "react": "18.3.1",
+    "react-dom": "18.3.1",
     "@emotion/react": "11.14.0",
     "@emotion/styled": "11.14.1",
     "@mui/icons-material": "7.3.5",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,17 +16,4 @@ export default defineConfig({
       '@': path.resolve(__dirname, './src'),
     },
   },
-  build: {
-    rollupOptions: {
-      external: ['react/jsx-runtime', 'react-dom/client', 'react', 'react-dom'],
-      output: {
-        globals: {
-          'react/jsx-runtime': 'jsxRuntime',
-          'react-dom/client': 'ReactDOM',
-          'react': 'React',
-          'react-dom': 'ReactDOM',
-        },
-      },
-    },
-  },
 })


### PR DESCRIPTION
…move library build config

- React and React-DOM are now regular dependencies since this is a web application
- Removed external modules and globals from Rollup build config
- This fixes 'Failed to resolve module specifier "react/jsx-runtime"' error