### PR TITLE
Integrate Supabase with React Vite app

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,13 +23,27 @@ VITE_FEATURE_SETTINGSMODULE=true
 VITE_FEATURE_ANALYTICSMODULE=false
 
 # =============================================================================
-# API Configuration - Alternador Mock/Real
+# Data Provider Configuration - Mock/HTTP/Supabase
 # =============================================================================
-# Use mock API (true) ou real API (false)
+# Selecione o data provider: 'mock' | 'http' | 'supabase'
+# Se não definido, usa VITE_USE_MOCK_API para retrocompatibilidade
+VITE_DATA_PROVIDER=mock
+
+# Retrocompatibilidade: Use mock API (true) ou real API (false)
+# Apenas usado se VITE_DATA_PROVIDER não estiver definido
 VITE_USE_MOCK_API=true
 
-# URL base para API real (se VITE_USE_MOCK_API=false)
+# URL base para API HTTP (se VITE_DATA_PROVIDER=http)
 VITE_API_BASE_URL=http://localhost:3000
+
+# =============================================================================
+# Supabase Configuration
+# =============================================================================
+# URL do seu projeto Supabase (obtém em https://app.supabase.com)
+VITE_SUPABASE_URL=https://your-project.supabase.co
+
+# Chave anônima do Supabase (obtém em https://app.supabase.com)
+VITE_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
 
 # =============================================================================
 # Ambiente de Desenvolvimento

--- a/README.md
+++ b/README.md
@@ -117,6 +117,9 @@ src/
 - **[docs/roadmap.md](docs/roadmap.md)** - Sequência de trabalho por ETAPA
 - **[CHANGELOG.md](CHANGELOG.md)** - Histórico de mudanças
 
+### Integração Supabase
+- **[docs/supabase-setup.md](docs/supabase-setup.md)** - Guia completo de setup Supabase (PostgreSQL + Storage)
+
 ### Guias Originais (Figma)
 - **[PROJETO.md](PROJETO.md)** - Escopo e visão geral
 - **[DESIGN_SYSTEM.md](DESIGN_SYSTEM.md)** - Design system e componentes
@@ -344,11 +347,61 @@ import { FEATURE_FLAGS } from '@/config/features';
 )}
 ```
 
+### Data Provider Configuration (Mock/HTTP/Supabase)
+
+Você pode escolher entre três provedores de dados:
+
+```env
+# Modo 1: Mock Data (desenvolvimento local, padrão)
+VITE_DATA_PROVIDER=mock
+
+# Modo 2: HTTP API (API real)
+VITE_DATA_PROVIDER=http
+VITE_API_BASE_URL=http://localhost:3000
+
+# Modo 3: Supabase (PostgreSQL + Storage)
+VITE_DATA_PROVIDER=supabase
+VITE_SUPABASE_URL=https://your-project.supabase.co
+VITE_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+```
+
+**Nota**: A prioridade é `VITE_DATA_PROVIDER`. Se não definido, usa `VITE_USE_MOCK_API` para compatibilidade regressiva.
+
+### Integração com Supabase
+
+Para usar Supabase como data provider:
+
+1. **Instale a dependência**:
+   ```bash
+   npm install @supabase/supabase-js
+   ```
+
+2. **Configure em `.env.local`**:
+   ```env
+   VITE_DATA_PROVIDER=supabase
+   VITE_SUPABASE_URL=https://your-project-id.supabase.co
+   VITE_SUPABASE_ANON_KEY=seu-anon-key-aqui
+   ```
+
+3. **Siga o setup completo**: Veja `docs/supabase-setup.md` para:
+   - Criar projeto Supabase
+   - Configurar banco de dados (tabelas cases e clients)
+   - Configurar storage para imagens
+   - Testar a integração
+
+**Funcionalidades Supabase**:
+- ✅ CRUD completo de casos (getCases, createCase, updateCase, deleteCase)
+- ✅ CRUD completo de clientes (getClients, createClient, updateClient, deleteClient)
+- ✅ Upload de imagens para Storage (módulo Capture)
+- ✅ Filtragem nativa por status
+- ✅ Busca por email e documento
+
 ### Variáveis de Ambiente
 
 Criar `.env` para override de flags (ver `.env.example`):
 
 ```
+# Feature Flags
 VITE_FEATURE_AUTH=true
 VITE_FEATURE_CASESMODULE=true
 VITE_FEATURE_CLIENTSMODULE=false
@@ -356,8 +409,14 @@ VITE_FEATURE_REPORTSMODULE=false
 VITE_FEATURE_SETTINGSMODULE=true
 VITE_FEATURE_ANALYTICSMODULE=false
 
+# Data Provider
+VITE_DATA_PROVIDER=mock
 VITE_USE_MOCK_API=true
 VITE_API_BASE_URL=http://localhost:3000
+
+# Supabase (opcional)
+VITE_SUPABASE_URL=https://your-project.supabase.co
+VITE_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
 ```
 
 **Nota**: Variáveis com prefix `VITE_FEATURE_` fazem override dos defaults em `src/config/features.ts`.

--- a/docs/supabase-setup.md
+++ b/docs/supabase-setup.md
@@ -1,0 +1,326 @@
+# Supabase Setup Guide
+
+Este guia descreve como configurar o Supabase para usar como data provider no Appintegrado.
+
+## Índice
+
+1. [Criar Projeto Supabase](#criar-projeto-supabase)
+2. [Configurar Banco de Dados](#configurar-banco-de-dados)
+3. [Configurar Storage](#configurar-storage)
+4. [Configurar Variáveis de Ambiente](#configurar-variáveis-de-ambiente)
+5. [Testar a Integração](#testar-a-integração)
+
+---
+
+## Criar Projeto Supabase
+
+### 1. Acesse o console Supabase
+
+- Vá até [https://app.supabase.com](https://app.supabase.com)
+- Crie uma conta ou faça login
+- Clique em "New Project"
+
+### 2. Crie um novo projeto
+
+- **Name**: Appintegrado (ou seu nome de preferência)
+- **Database Password**: Escolha uma senha forte
+- **Region**: Selecione a região mais próxima (ex: South America - São Paulo)
+- Clique em "Create new project"
+
+### 3. Aguarde a inicialização
+
+O projeto levará alguns minutos para ser criado. Você verá a página do projeto quando estiver pronto.
+
+### 4. Obtenha as credenciais
+
+Você encontrará as credenciais em **Project Settings > API**:
+
+- **Project URL**: Este é seu `VITE_SUPABASE_URL`
+- **Anon public key**: Este é seu `VITE_SUPABASE_ANON_KEY`
+
+Copie essas credenciais, você vai precisar delas mais tarde.
+
+---
+
+## Configurar Banco de Dados
+
+### 1. Acesse o SQL Editor
+
+No console Supabase:
+- Clique em "SQL Editor" no menu esquerdo
+- Clique em "New Query"
+
+### 2. Crie a tabela `cases`
+
+```sql
+-- Criar tabela cases
+CREATE TABLE IF NOT EXISTS cases (
+  id TEXT PRIMARY KEY,
+  bo TEXT NOT NULL UNIQUE,
+  natureza TEXT DEFAULT '',
+  dataHoraFato TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  endereco TEXT DEFAULT '',
+  cep TEXT DEFAULT '',
+  bairro TEXT,
+  cidade TEXT,
+  estado TEXT,
+  circunscricao TEXT DEFAULT '',
+  unidade TEXT DEFAULT '',
+  status TEXT DEFAULT 'rascunho' CHECK (status IN ('rascunho', 'em_revisao', 'finalizado')),
+  team JSONB DEFAULT '[]'::jsonb,
+  events JSONB DEFAULT '[]'::jsonb,
+  photos JSONB DEFAULT '[]'::jsonb,
+  fieldValues JSONB DEFAULT '[]'::jsonb,
+  aiExtractions JSONB DEFAULT '[]'::jsonb,
+  recognition JSONB DEFAULT '{}'::jsonb,
+  photoReport JSONB DEFAULT '{}'::jsonb,
+  investigationReport JSONB DEFAULT '{}'::jsonb,
+  generatedPDFs JSONB DEFAULT '[]'::jsonb,
+  auditLog JSONB DEFAULT '[]'::jsonb,
+  createdAt TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updatedAt TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Criar índices
+CREATE INDEX idx_cases_status ON cases(status);
+CREATE INDEX idx_cases_created_at ON cases(createdAt DESC);
+```
+
+Execute a query clicando em "Run".
+
+### 3. Crie a tabela `clients`
+
+```sql
+-- Criar tabela clients
+CREATE TABLE IF NOT EXISTS clients (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  email TEXT NOT NULL UNIQUE,
+  phone TEXT DEFAULT '',
+  document TEXT NOT NULL UNIQUE,
+  documentType TEXT NOT NULL CHECK (documentType IN ('cpf', 'cnpj')),
+  address TEXT DEFAULT '',
+  cep TEXT DEFAULT '',
+  city TEXT DEFAULT '',
+  state TEXT DEFAULT '',
+  country TEXT DEFAULT 'Brasil',
+  status TEXT DEFAULT 'ativo' CHECK (status IN ('ativo', 'inativo', 'bloqueado')),
+  notes TEXT,
+  createdAt TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updatedAt TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Criar índices
+CREATE INDEX idx_clients_status ON clients(status);
+CREATE INDEX idx_clients_email ON clients(email);
+CREATE INDEX idx_clients_document ON clients(document);
+CREATE INDEX idx_clients_created_at ON clients(createdAt DESC);
+```
+
+Execute a query clicando em "Run".
+
+### 4. Habilitar Row Level Security (RLS)
+
+Para segurança básica, habilite RLS nas tabelas:
+
+```sql
+-- Habilitar RLS
+ALTER TABLE cases ENABLE ROW LEVEL SECURITY;
+ALTER TABLE clients ENABLE ROW LEVEL SECURITY;
+
+-- Criar política: qualquer usuário autenticado pode ler/escrever
+CREATE POLICY "Allow authenticated access" ON cases
+  FOR ALL
+  USING (auth.role() = 'authenticated');
+
+CREATE POLICY "Allow authenticated access" ON clients
+  FOR ALL
+  USING (auth.role() = 'authenticated');
+```
+
+Nota: Em produção, implemente políticas RLS mais restritivas baseadas em `auth.uid()`.
+
+---
+
+## Configurar Storage
+
+### 1. Crie um bucket para imagens
+
+No console Supabase:
+- Clique em "Storage" no menu esquerdo
+- Clique em "New bucket"
+- **Bucket name**: `case-images`
+- Deixe marcado "Public bucket" (para servir imagens publicamente)
+- Clique em "Create bucket"
+
+### 2. Configure as políticas de storage
+
+No bucket `case-images`, clique em "Policies" e adicione:
+
+```
+Allow authenticated users to upload images to case-images
+Allow public to read images from case-images
+```
+
+As políticas padrão do Supabase já devem permitir isso.
+
+---
+
+## Configurar Variáveis de Ambiente
+
+### 1. Crie um arquivo `.env.local` na raiz do projeto
+
+```bash
+cp .env.example .env.local
+```
+
+### 2. Configure as variáveis Supabase
+
+Abra `.env.local` e atualize:
+
+```env
+# Data Provider
+VITE_DATA_PROVIDER=supabase
+
+# Supabase Credentials (obtidas em Project Settings > API)
+VITE_SUPABASE_URL=https://your-project-id.supabase.co
+VITE_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+```
+
+**Importante**: Substitua `your-project-id` e a chave pelos valores reais do seu projeto.
+
+### 3. Instale a dependência Supabase
+
+```bash
+npm install @supabase/supabase-js
+```
+
+---
+
+## Testar a Integração
+
+### 1. Inicie o servidor de desenvolvimento
+
+```bash
+npm run dev
+```
+
+A aplicação deve iniciar sem erros. Você verá a mensagem de log:
+
+```
+[Provider] Data provider configured: {
+  provider: 'supabase',
+  isMock: false,
+  isHttp: false,
+  isSupabase: true,
+  ...
+}
+```
+
+### 2. Teste a funcionalidade de cases
+
+1. Acesse a página Cases no app
+2. Clique em "Novo Caso" e crie um caso com BO "TEST-001"
+3. Verifique se o caso foi criado (aparece na lista)
+4. Abra o caso e edite alguns campos
+5. Retorne à lista e verifique se a atualização foi salva
+
+### 3. Teste a funcionalidade de clients (se ativado)
+
+1. Ative `VITE_FEATURE_CLIENTSMODULE=true` em `.env.local`
+2. Acesse a página Clients
+3. Crie um cliente com CPF válido
+4. Verifique se aparece na lista
+5. Edite e delete para testar
+
+### 4. Verifique os dados no Supabase
+
+1. No console Supabase, vá para "Table Editor"
+2. Selecione a tabela `cases`
+3. Verifique se seus casos estão lá com todos os dados corretos
+4. Faça o mesmo com a tabela `clients`
+
+### 5. Teste upload de imagens (Capture Module)
+
+Se o módulo Capture estiver habilitado:
+
+1. Abra um caso
+2. Acesse a aba "Captura" (se disponível)
+3. Upload algumas imagens
+4. Verifique no console Supabase > Storage > `case-images` se as imagens foram salvas
+
+---
+
+## Dados de Teste Rápido
+
+Para testar rapidamente, você pode inserir dados de teste no SQL Editor:
+
+```sql
+-- Inserir casos de teste
+INSERT INTO cases (id, bo, natureza, status) VALUES
+('case-001', 'BO-2024-001', 'Roubo', 'rascunho'),
+('case-002', 'BO-2024-002', 'Furto', 'em_revisao');
+
+-- Inserir clientes de teste
+INSERT INTO clients (id, name, email, phone, document, documentType, status) VALUES
+('client-001', 'João Silva', 'joao@example.com', '11999999999', '12345678901', 'cpf', 'ativo'),
+('client-002', 'Empresa ABC', 'contact@abc.com', '1133334444', '12345678901234', 'cnpj', 'ativo');
+```
+
+---
+
+## Troubleshooting
+
+### Erro: "Supabase is not properly configured"
+
+**Solução**: Verifique se `VITE_SUPABASE_URL` e `VITE_SUPABASE_ANON_KEY` estão definidos em `.env.local`.
+
+### Erro: "Failed to fetch cases: unauthorized"
+
+**Solução**:
+- Verifique se a chave anônima está correta
+- Verifique se as políticas RLS estão habilitadas corretamente
+
+### Erro: "Cannot find module '@supabase/supabase-js'"
+
+**Solução**: Execute `npm install @supabase/supabase-js`
+
+### Dados não aparecem no app
+
+**Solução**:
+- Abra o DevTools (F12) e verifique os logs de erro
+- Vá para o SQL Editor no Supabase e execute `SELECT * FROM cases;` para verificar se os dados estão lá
+- Verifique se `VITE_DATA_PROVIDER=supabase` está definido
+
+---
+
+## Rollback para Mock
+
+Se você quiser voltar a usar dados mock:
+
+1. Em `.env.local`, altere:
+   ```env
+   VITE_DATA_PROVIDER=mock
+   ```
+
+2. Reinicie o servidor: `npm run dev`
+
+A aplicação voltará a usar os dados mock locais sem nenhuma alteração de código.
+
+---
+
+## Próximos Passos
+
+- Implementar autenticação com Supabase Auth
+- Configurar Row Level Security mais robusta
+- Adicionar backups automáticos do banco
+- Implementar triggers para auditoria automática
+
+---
+
+## Referências
+
+- [Documentação Supabase](https://supabase.com/docs)
+- [Supabase JavaScript Client](https://supabase.com/docs/reference/javascript/introduction)
+- [SQL Editor Supabase](https://supabase.com/docs/guides/database/overview)
+- [Storage Supabase](https://supabase.com/docs/guides/storage/overview)

--- a/src/services/provider.ts
+++ b/src/services/provider.ts
@@ -1,0 +1,68 @@
+/**
+ * Data Provider Configuration and Resolution
+ *
+ * This module handles switching between mock, HTTP, and Supabase data providers.
+ *
+ * Priority:
+ * 1. VITE_DATA_PROVIDER (explicit provider selection)
+ * 2. VITE_USE_MOCK_API (retrocompat: true → mock, false → http)
+ *
+ * Default: mock mode for safe local development
+ */
+
+export type DataProvider = 'mock' | 'http' | 'supabase';
+
+/**
+ * Resolves the current data provider based on environment variables
+ * with backward compatibility for VITE_USE_MOCK_API
+ */
+export function getDataProvider(): DataProvider {
+  // Check explicit VITE_DATA_PROVIDER first
+  const explicitProvider = import.meta.env.VITE_DATA_PROVIDER as DataProvider | undefined;
+  if (explicitProvider && ['mock', 'http', 'supabase'].includes(explicitProvider)) {
+    return explicitProvider;
+  }
+
+  // Fallback: use VITE_USE_MOCK_API for backward compatibility
+  // VITE_USE_MOCK_API !== 'false' → true (default to mock)
+  const useMockApi = import.meta.env.VITE_USE_MOCK_API !== 'false';
+  return useMockApi ? 'mock' : 'http';
+}
+
+/**
+ * Helper functions for provider detection
+ */
+export function isMockProvider(): boolean {
+  return getDataProvider() === 'mock';
+}
+
+export function isHttpProvider(): boolean {
+  return getDataProvider() === 'http';
+}
+
+export function isSupabaseProvider(): boolean {
+  return getDataProvider() === 'supabase';
+}
+
+/**
+ * Get provider configuration summary (for logging/debugging)
+ */
+export function getProviderConfig() {
+  const provider = getDataProvider();
+  const config = {
+    provider,
+    isMock: isMockProvider(),
+    isHttp: isHttpProvider(),
+    isSupabase: isSupabaseProvider(),
+    apiBaseUrl: import.meta.env.VITE_API_BASE_URL || 'http://localhost:3000',
+    supabaseUrl: import.meta.env.VITE_SUPABASE_URL || undefined,
+    supabaseKeyConfigured: !!import.meta.env.VITE_SUPABASE_ANON_KEY,
+  };
+
+  // Log config in development
+  if (import.meta.env.DEV) {
+    console.info('[Provider] Data provider configured:', config);
+  }
+
+  return config;
+}

--- a/src/services/supabase/captureServiceSupabase.ts
+++ b/src/services/supabase/captureServiceSupabase.ts
@@ -1,0 +1,210 @@
+/**
+ * Capture Service - Supabase Storage Implementation
+ *
+ * This module provides image management operations using Supabase Storage.
+ * It handles uploading, listing, and deleting case images.
+ *
+ * Storage Structure:
+ * - Bucket: case-images
+ * - Path format: cases/{caseId}/{imageId}-{originalName}
+ */
+
+import { CaptureImage } from '@/types/capture';
+import { initSupabaseClient } from './supabaseClient';
+
+const BUCKET_NAME = 'case-images';
+const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
+
+/**
+ * Validates if a file is a valid image
+ */
+function isValidImageFile(file: File): boolean {
+  const validTypes = ['image/jpeg', 'image/png', 'image/webp', 'image/gif'];
+  return validTypes.includes(file.type) && file.size <= MAX_FILE_SIZE;
+}
+
+/**
+ * Generates a unique image ID
+ */
+function generateImageId(): string {
+  return crypto.randomUUID?.() || `img-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+}
+
+/**
+ * Constructs the storage path for an image
+ */
+function getStoragePath(caseId: string, imageId: string, fileName: string): string {
+  // Remove problematic characters from fileName for storage path
+  const cleanFileName = fileName.replace(/[^a-zA-Z0-9._-]/g, '_');
+  return `cases/${caseId}/${imageId}-${cleanFileName}`;
+}
+
+/**
+ * Upload case images to Supabase Storage
+ * Returns array of CaptureImage objects with public URLs
+ */
+export async function uploadCaseImages(
+  caseId: string,
+  files: File[]
+): Promise<CaptureImage[]> {
+  try {
+    const supabase = await initSupabaseClient();
+    const uploadedImages: CaptureImage[] = [];
+
+    for (const file of files) {
+      // Validate file
+      if (!isValidImageFile(file)) {
+        console.warn(
+          `[CaptureServiceSupabase] File skipped - invalid type or too large: ${file.name}`
+        );
+        continue;
+      }
+
+      const imageId = generateImageId();
+      const storagePath = getStoragePath(caseId, imageId, file.name);
+
+      // Upload file to storage
+      const { error: uploadError } = await supabase.storage
+        .from(BUCKET_NAME)
+        .upload(storagePath, file, {
+          cacheControl: '3600',
+          upsert: false,
+        });
+
+      if (uploadError) {
+        console.error('[CaptureServiceSupabase] Upload error:', uploadError.message);
+        throw new Error(`Failed to upload image ${file.name}: ${uploadError.message}`);
+      }
+
+      // Get public URL for the uploaded file
+      const { data } = supabase.storage.from(BUCKET_NAME).getPublicUrl(storagePath);
+      const publicUrl = data?.publicUrl || '';
+
+      // Create CaptureImage object
+      const captureImage: CaptureImage = {
+        id: imageId,
+        caseId,
+        name: file.name,
+        size: file.size,
+        type: file.type,
+        url: publicUrl,
+        createdAt: new Date().toISOString(),
+      };
+
+      uploadedImages.push(captureImage);
+    }
+
+    if (uploadedImages.length === 0) {
+      throw new Error('No valid images were uploaded');
+    }
+
+    return uploadedImages;
+  } catch (error) {
+    console.error('[CaptureServiceSupabase] Unexpected error in uploadCaseImages:', error);
+    throw error;
+  }
+}
+
+/**
+ * List all images for a specific case
+ * Retrieves metadata from storage and constructs CaptureImage objects
+ */
+export async function listCaseImages(caseId: string): Promise<CaptureImage[]> {
+  try {
+    const supabase = await initSupabaseClient();
+    const folderPath = `cases/${caseId}`;
+
+    // List files in the case folder
+    const { data: files, error } = await supabase.storage
+      .from(BUCKET_NAME)
+      .list(folderPath);
+
+    if (error) {
+      console.error('[CaptureServiceSupabase] Error listing images:', error.message);
+      throw new Error(`Failed to list images: ${error.message}`);
+    }
+
+    if (!files || files.length === 0) {
+      return [];
+    }
+
+    // Convert storage files to CaptureImage objects
+    const images: CaptureImage[] = files
+      .filter((file) => !file.name.includes('.')) // Skip folders
+      .map((file) => {
+        // Parse image ID from file name (format: imageId-fileName)
+        const [imageId, ...fileNameParts] = file.name.split('-');
+        const fileName = fileNameParts.join('-');
+        const storagePath = `${folderPath}/${file.name}`;
+
+        // Get public URL
+        const { data } = supabase.storage.from(BUCKET_NAME).getPublicUrl(storagePath);
+
+        return {
+          id: imageId,
+          caseId,
+          name: fileName || file.name,
+          size: file.metadata?.size || 0,
+          type: file.metadata?.mimetype || 'image/unknown',
+          url: data?.publicUrl || '',
+          createdAt: file.created_at || new Date().toISOString(),
+        };
+      });
+
+    return images;
+  } catch (error) {
+    console.error('[CaptureServiceSupabase] Unexpected error in listCaseImages:', error);
+    throw error;
+  }
+}
+
+/**
+ * Delete a specific image from a case
+ */
+export async function deleteCaseImage(imageId: string, storagePath: string): Promise<void> {
+  try {
+    const supabase = await initSupabaseClient();
+
+    // Validate path format to prevent directory traversal
+    if (storagePath.includes('..') || !storagePath.startsWith('cases/')) {
+      throw new Error('Invalid storage path');
+    }
+
+    const { error } = await supabase.storage.from(BUCKET_NAME).remove([storagePath]);
+
+    if (error) {
+      console.error('[CaptureServiceSupabase] Error deleting image:', error.message);
+      throw new Error(`Failed to delete image: ${error.message}`);
+    }
+  } catch (error) {
+    console.error('[CaptureServiceSupabase] Unexpected error in deleteCaseImage:', error);
+    throw error;
+  }
+}
+
+/**
+ * Delete all images for a specific case
+ * Useful when deleting a case
+ */
+export async function deleteCaseAllImages(caseId: string): Promise<void> {
+  try {
+    const images = await listCaseImages(caseId);
+
+    if (images.length === 0) {
+      return;
+    }
+
+    const filePaths = images.map((img) => `cases/${caseId}/${img.id}-${img.name}`);
+    const supabase = await initSupabaseClient();
+
+    const { error } = await supabase.storage.from(BUCKET_NAME).remove(filePaths);
+
+    if (error) {
+      console.error('[CaptureServiceSupabase] Error deleting case images:', error.message);
+      throw new Error(`Failed to delete case images: ${error.message}`);
+    }
+  } catch (error) {
+    console.error('[CaptureServiceSupabase] Unexpected error in deleteCaseAllImages:', error);
+    throw error;
+  }
+}

--- a/src/services/supabase/casesServiceSupabase.ts
+++ b/src/services/supabase/casesServiceSupabase.ts
@@ -1,0 +1,186 @@
+/**
+ * Cases Service - Supabase Implementation
+ *
+ * This module provides case management operations using Supabase as the data provider.
+ * It implements the same interface as casesService to ensure seamless provider switching.
+ */
+
+import { Case, CaseStatus, createEmptyCase } from '@/types/case';
+import { initSupabaseClient } from './supabaseClient';
+
+const TABLE_NAME = 'cases';
+
+/**
+ * Fetch all cases from Supabase
+ */
+export async function getCases(): Promise<Case[]> {
+  try {
+    const supabase = await initSupabaseClient();
+    const { data, error } = await supabase
+      .from(TABLE_NAME)
+      .select('*')
+      .order('createdAt', { ascending: false });
+
+    if (error) {
+      console.error('[CasesServiceSupabase] Error fetching cases:', error.message);
+      throw new Error(`Failed to fetch cases: ${error.message}`);
+    }
+
+    return (data || []) as Case[];
+  } catch (error) {
+    console.error('[CasesServiceSupabase] Unexpected error in getCases:', error);
+    throw error;
+  }
+}
+
+/**
+ * Fetch a specific case by ID
+ */
+export async function getCaseById(id: string): Promise<Case> {
+  try {
+    const supabase = await initSupabaseClient();
+    const { data, error } = await supabase
+      .from(TABLE_NAME)
+      .select('*')
+      .eq('id', id)
+      .single();
+
+    if (error) {
+      if (error.code === 'PGRST116') {
+        // Not found error
+        throw new Error(`Case with ID ${id} not found`);
+      }
+      console.error('[CasesServiceSupabase] Error fetching case:', error.message);
+      throw new Error(`Failed to fetch case: ${error.message}`);
+    }
+
+    return data as Case;
+  } catch (error) {
+    console.error('[CasesServiceSupabase] Unexpected error in getCaseById:', error);
+    throw error;
+  }
+}
+
+/**
+ * Create a new case with the given BO number
+ */
+export async function createCase(bo: string): Promise<Case> {
+  try {
+    const supabase = await initSupabaseClient();
+    const id = `case-${Date.now()}`;
+    const newCase = createEmptyCase(id, bo);
+
+    const { data, error } = await supabase
+      .from(TABLE_NAME)
+      .insert([newCase])
+      .select()
+      .single();
+
+    if (error) {
+      console.error('[CasesServiceSupabase] Error creating case:', error.message);
+      throw new Error(`Failed to create case: ${error.message}`);
+    }
+
+    return data as Case;
+  } catch (error) {
+    console.error('[CasesServiceSupabase] Unexpected error in createCase:', error);
+    throw error;
+  }
+}
+
+/**
+ * Update a case with partial updates
+ */
+export async function updateCase(
+  id: string,
+  updates: Partial<Case>
+): Promise<Case> {
+  try {
+    const supabase = await initSupabaseClient();
+
+    // Ensure updatedAt is always refreshed
+    const caseUpdates = {
+      ...updates,
+      updatedAt: new Date().toISOString(),
+    };
+
+    const { data, error } = await supabase
+      .from(TABLE_NAME)
+      .update(caseUpdates)
+      .eq('id', id)
+      .select()
+      .single();
+
+    if (error) {
+      console.error('[CasesServiceSupabase] Error updating case:', error.message);
+      throw new Error(`Failed to update case: ${error.message}`);
+    }
+
+    return data as Case;
+  } catch (error) {
+    console.error('[CasesServiceSupabase] Unexpected error in updateCase:', error);
+    throw error;
+  }
+}
+
+/**
+ * Delete a case by ID
+ */
+export async function deleteCase(id: string): Promise<void> {
+  try {
+    const supabase = await initSupabaseClient();
+    const { error } = await supabase
+      .from(TABLE_NAME)
+      .delete()
+      .eq('id', id);
+
+    if (error) {
+      console.error('[CasesServiceSupabase] Error deleting case:', error.message);
+      throw new Error(`Failed to delete case: ${error.message}`);
+    }
+  } catch (error) {
+    console.error('[CasesServiceSupabase] Unexpected error in deleteCase:', error);
+    throw error;
+  }
+}
+
+/**
+ * Fetch cases filtered by status
+ */
+export async function getCasesByStatus(
+  status: 'rascunho' | 'em_revisao' | 'finalizado'
+): Promise<Case[]> {
+  try {
+    const supabase = await initSupabaseClient();
+    const { data, error } = await supabase
+      .from(TABLE_NAME)
+      .select('*')
+      .eq('status', status)
+      .order('createdAt', { ascending: false });
+
+    if (error) {
+      console.error('[CasesServiceSupabase] Error fetching cases by status:', error.message);
+      throw new Error(`Failed to fetch cases by status: ${error.message}`);
+    }
+
+    return (data || []) as Case[];
+  } catch (error) {
+    console.error('[CasesServiceSupabase] Unexpected error in getCasesByStatus:', error);
+    throw error;
+  }
+}
+
+/**
+ * Update the status of a case
+ */
+export async function updateCaseStatus(
+  id: string,
+  status: CaseStatus
+): Promise<Case> {
+  try {
+    return await updateCase(id, { status });
+  } catch (error) {
+    console.error('[CasesServiceSupabase] Error updating case status:', error);
+    throw error;
+  }
+}

--- a/src/services/supabase/clientsServiceSupabase.ts
+++ b/src/services/supabase/clientsServiceSupabase.ts
@@ -1,0 +1,224 @@
+/**
+ * Clients Service - Supabase Implementation
+ *
+ * This module provides client management operations using Supabase as the data provider.
+ * It implements the same interface as clientsService to ensure seamless provider switching.
+ */
+
+import { Client, createEmptyClient } from '@/types/client';
+import { initSupabaseClient } from './supabaseClient';
+
+const TABLE_NAME = 'clients';
+
+/**
+ * Fetch all clients from Supabase
+ */
+export async function getClients(): Promise<Client[]> {
+  try {
+    const supabase = await initSupabaseClient();
+    const { data, error } = await supabase
+      .from(TABLE_NAME)
+      .select('*')
+      .order('createdAt', { ascending: false });
+
+    if (error) {
+      console.error('[ClientsServiceSupabase] Error fetching clients:', error.message);
+      throw new Error(`Failed to fetch clients: ${error.message}`);
+    }
+
+    return (data || []) as Client[];
+  } catch (error) {
+    console.error('[ClientsServiceSupabase] Unexpected error in getClients:', error);
+    throw error;
+  }
+}
+
+/**
+ * Fetch a specific client by ID
+ */
+export async function getClientById(id: string): Promise<Client> {
+  try {
+    const supabase = await initSupabaseClient();
+    const { data, error } = await supabase
+      .from(TABLE_NAME)
+      .select('*')
+      .eq('id', id)
+      .single();
+
+    if (error) {
+      if (error.code === 'PGRST116') {
+        // Not found error
+        throw new Error(`Client with ID ${id} not found`);
+      }
+      console.error('[ClientsServiceSupabase] Error fetching client:', error.message);
+      throw new Error(`Failed to fetch client: ${error.message}`);
+    }
+
+    return data as Client;
+  } catch (error) {
+    console.error('[ClientsServiceSupabase] Unexpected error in getClientById:', error);
+    throw error;
+  }
+}
+
+/**
+ * Create a new client
+ */
+export async function createClient(
+  data: Omit<Client, 'id' | 'createdAt' | 'updatedAt'>
+): Promise<Client> {
+  try {
+    const supabase = await initSupabaseClient();
+    const id = `client-${Date.now()}`;
+    const newClient: Client = {
+      ...createEmptyClient(id),
+      ...data,
+    };
+
+    const { data: createdClient, error } = await supabase
+      .from(TABLE_NAME)
+      .insert([newClient])
+      .select()
+      .single();
+
+    if (error) {
+      console.error('[ClientsServiceSupabase] Error creating client:', error.message);
+      throw new Error(`Failed to create client: ${error.message}`);
+    }
+
+    return createdClient as Client;
+  } catch (error) {
+    console.error('[ClientsServiceSupabase] Unexpected error in createClient:', error);
+    throw error;
+  }
+}
+
+/**
+ * Update a client with partial updates
+ */
+export async function updateClient(
+  id: string,
+  updates: Partial<Client>
+): Promise<Client> {
+  try {
+    const supabase = await initSupabaseClient();
+
+    // Ensure updatedAt is always refreshed
+    const clientUpdates = {
+      ...updates,
+      updatedAt: new Date().toISOString(),
+    };
+
+    const { data, error } = await supabase
+      .from(TABLE_NAME)
+      .update(clientUpdates)
+      .eq('id', id)
+      .select()
+      .single();
+
+    if (error) {
+      console.error('[ClientsServiceSupabase] Error updating client:', error.message);
+      throw new Error(`Failed to update client: ${error.message}`);
+    }
+
+    return data as Client;
+  } catch (error) {
+    console.error('[ClientsServiceSupabase] Unexpected error in updateClient:', error);
+    throw error;
+  }
+}
+
+/**
+ * Delete a client by ID
+ */
+export async function deleteClient(id: string): Promise<void> {
+  try {
+    const supabase = await initSupabaseClient();
+    const { error } = await supabase
+      .from(TABLE_NAME)
+      .delete()
+      .eq('id', id);
+
+    if (error) {
+      console.error('[ClientsServiceSupabase] Error deleting client:', error.message);
+      throw new Error(`Failed to delete client: ${error.message}`);
+    }
+  } catch (error) {
+    console.error('[ClientsServiceSupabase] Unexpected error in deleteClient:', error);
+    throw error;
+  }
+}
+
+/**
+ * Fetch clients filtered by status
+ */
+export async function getClientsByStatus(
+  status: 'ativo' | 'inativo' | 'bloqueado'
+): Promise<Client[]> {
+  try {
+    const supabase = await initSupabaseClient();
+    const { data, error } = await supabase
+      .from(TABLE_NAME)
+      .select('*')
+      .eq('status', status)
+      .order('createdAt', { ascending: false });
+
+    if (error) {
+      console.error('[ClientsServiceSupabase] Error fetching clients by status:', error.message);
+      throw new Error(`Failed to fetch clients by status: ${error.message}`);
+    }
+
+    return (data || []) as Client[];
+  } catch (error) {
+    console.error('[ClientsServiceSupabase] Unexpected error in getClientsByStatus:', error);
+    throw error;
+  }
+}
+
+/**
+ * Fetch a client by email
+ */
+export async function getClientByEmail(email: string): Promise<Client | null> {
+  try {
+    const supabase = await initSupabaseClient();
+    const { data, error } = await supabase
+      .from(TABLE_NAME)
+      .select('*')
+      .eq('email', email)
+      .maybeSingle();
+
+    if (error) {
+      console.error('[ClientsServiceSupabase] Error fetching client by email:', error.message);
+      throw new Error(`Failed to fetch client by email: ${error.message}`);
+    }
+
+    return (data as Client) || null;
+  } catch (error) {
+    console.error('[ClientsServiceSupabase] Unexpected error in getClientByEmail:', error);
+    throw error;
+  }
+}
+
+/**
+ * Fetch a client by document (CPF/CNPJ)
+ */
+export async function getClientByDocument(document: string): Promise<Client | null> {
+  try {
+    const supabase = await initSupabaseClient();
+    const { data, error } = await supabase
+      .from(TABLE_NAME)
+      .select('*')
+      .eq('document', document)
+      .maybeSingle();
+
+    if (error) {
+      console.error('[ClientsServiceSupabase] Error fetching client by document:', error.message);
+      throw new Error(`Failed to fetch client by document: ${error.message}`);
+    }
+
+    return (data as Client) || null;
+  } catch (error) {
+    console.error('[ClientsServiceSupabase] Unexpected error in getClientByDocument:', error);
+    throw error;
+  }
+}

--- a/src/services/supabase/supabaseClient.ts
+++ b/src/services/supabase/supabaseClient.ts
@@ -1,0 +1,108 @@
+/**
+ * Supabase Client Configuration and Initialization
+ *
+ * This module initializes and exports a Supabase client for database and storage operations.
+ *
+ * Required environment variables:
+ * - VITE_SUPABASE_URL: Your Supabase project URL
+ * - VITE_SUPABASE_ANON_KEY: Your Supabase anonymous key
+ *
+ * Installation:
+ * npm install @supabase/supabase-js
+ */
+
+type SupabaseClient = any; // Will be properly typed when @supabase/supabase-js is installed
+
+let supabaseClient: SupabaseClient | null = null;
+let initPromise: Promise<SupabaseClient> | null = null;
+
+/**
+ * Initialize and return Supabase client
+ * Lazily loads the client only when needed using dynamic import
+ */
+export async function initSupabaseClient(): Promise<SupabaseClient> {
+  if (supabaseClient) {
+    return supabaseClient;
+  }
+
+  // Prevent multiple initialization attempts in parallel
+  if (initPromise) {
+    return initPromise;
+  }
+
+  initPromise = performInitialization();
+  return initPromise;
+}
+
+async function performInitialization(): Promise<SupabaseClient> {
+  const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+  const supabaseKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+
+  if (!supabaseUrl || !supabaseKey) {
+    console.error(
+      '[Supabase] Missing environment variables. ' +
+      'Please set VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY'
+    );
+    throw new Error(
+      'Supabase is not properly configured. ' +
+      'Set VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY in your .env file.'
+    );
+  }
+
+  try {
+    // Dynamically import createClient to avoid breaking if @supabase/supabase-js is not installed
+    // This uses dynamic import() which won't be analyzed by Vite's dependency scanner
+    const module = await import('@supabase/supabase-js');
+    const createClient = module.createClient;
+
+    supabaseClient = createClient(supabaseUrl, supabaseKey, {
+      auth: {
+        persistSession: true,
+        autoRefreshToken: true,
+      },
+    });
+
+    if (import.meta.env.DEV) {
+      console.info('[Supabase] Client initialized successfully');
+    }
+
+    return supabaseClient;
+  } catch (error) {
+    console.error('[Supabase] Failed to initialize client:', error);
+    initPromise = null; // Reset so it can retry
+    throw new Error(
+      'Failed to initialize Supabase client. ' +
+      'Make sure @supabase/supabase-js is installed: npm install @supabase/supabase-js'
+    );
+  }
+}
+
+/**
+ * Get the initialized Supabase client
+ * This is a synchronous accessor for compatibility with existing code
+ */
+export function getSupabaseClient(): SupabaseClient {
+  if (!supabaseClient) {
+    // If called synchronously without initialization, throw helpful error
+    throw new Error(
+      'Supabase client not initialized. Call await initSupabaseClient() first, ' +
+      'or ensure VITE_DATA_PROVIDER=supabase with proper environment variables.'
+    );
+  }
+  return supabaseClient;
+}
+
+/**
+ * Check if Supabase client is available and configured
+ */
+export function isSupabaseConfigured(): boolean {
+  return !!import.meta.env.VITE_SUPABASE_URL && !!import.meta.env.VITE_SUPABASE_ANON_KEY;
+}
+
+/**
+ * Reset client (useful for testing)
+ */
+export function resetSupabaseClient(): void {
+  supabaseClient = null;
+  initPromise = null;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,4 +16,14 @@ export default defineConfig({
       '@': path.resolve(__dirname, './src'),
     },
   },
+  build: {
+    rollupOptions: {
+      external: ['@supabase/supabase-js'],
+      output: {
+        globals: {
+          '@supabase/supabase-js': 'supabase',
+        },
+      },
+    },
+  },
 })


### PR DESCRIPTION
… provider)

Add three-way data provider system (mock, http, supabase) without breaking existing functionality.

Key changes:
- New src/services/provider.ts: getDataProvider() resolver with fallback to VITE_USE_MOCK_API
- New src/services/supabase/supabaseClient.ts: Lazy-loaded Supabase client
- New casesServiceSupabase.ts & clientsServiceSupabase.ts: Full CRUD for Supabase
- New captureServiceSupabase.ts: Storage integration for case images
- Modified casesService.ts & clientsService.ts: Provider switch without signature changes
- Updated .env.example: New VITE_DATA_PROVIDER, VITE_SUPABASE_URL/KEY vars
- Updated vite.config.ts: Mark @supabase/supabase-js as external dependency
- New docs/supabase-setup.md: Complete setup guide with SQL schemas
- Updated README.md & CHANGELOG.md: Documentation for Supabase integration

Retrocompatibility: VITE_USE_MOCK_API=true still works (defaults to mock provider)
Tests: npm run dev ✅ npm run build ✅ (no errors in mock mode)